### PR TITLE
CMB-8: Add list schema migration

### DIFF
--- a/db/migrations/002_list_schema_down.sql
+++ b/db/migrations/002_list_schema_down.sql
@@ -1,0 +1,14 @@
+-- CMB-8: Rollback list schema
+
+-- Drop triggers first
+DROP TRIGGER IF EXISTS list_set_updated_at ON list;
+
+-- Drop indexes
+DROP INDEX IF EXISTS idx_list_mech_mech_id;
+DROP INDEX IF EXISTS idx_list_mech_list_id;
+DROP INDEX IF EXISTS idx_list_created_at;
+DROP INDEX IF EXISTS idx_list_owner;
+
+-- Drop tables (foreign key constraints will prevent dropping in wrong order)
+DROP TABLE IF EXISTS list_mech;
+DROP TABLE IF EXISTS list;

--- a/db/migrations/002_list_schema_up.sql
+++ b/db/migrations/002_list_schema_up.sql
@@ -1,0 +1,36 @@
+-- CMB-8: List schema for user-created mech lists
+
+-- Lists table for user-created collections
+CREATE TABLE IF NOT EXISTS list (
+  id            BIGSERIAL PRIMARY KEY,
+  name          TEXT NOT NULL,
+  owner         TEXT NOT NULL,
+  faction       TEXT,
+  notes         TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  
+  -- Ensure list names are unique per owner
+  UNIQUE (owner, name)
+);
+
+-- Junction table for list-mech relationships
+CREATE TABLE IF NOT EXISTS list_mech (
+  list_id   BIGINT NOT NULL REFERENCES list(id) ON DELETE CASCADE,
+  mech_id   BIGINT NOT NULL REFERENCES mech(id) ON DELETE CASCADE,
+  quantity  INTEGER NOT NULL DEFAULT 1 CHECK (quantity > 0),
+  
+  PRIMARY KEY (list_id, mech_id)
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_list_owner ON list (owner);
+CREATE INDEX IF NOT EXISTS idx_list_created_at ON list (created_at);
+CREATE INDEX IF NOT EXISTS idx_list_mech_list_id ON list_mech (list_id);
+CREATE INDEX IF NOT EXISTS idx_list_mech_mech_id ON list_mech (mech_id);
+
+-- Updated at trigger for lists
+DROP TRIGGER IF EXISTS list_set_updated_at ON list;
+CREATE TRIGGER list_set_updated_at
+BEFORE UPDATE ON list
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
## Summary
Adds list schema to support user-created mech collections per CMB-8 requirements.

## Changes
- ✅ **List Table**: Core table for user mech lists (id, name, owner, faction, notes, timestamps)
- ✅ **List-Mech Junction**: Many-to-many relationship with quantity support
- ✅ **Foreign Key Constraints**: Proper referential integrity with cascade deletes
- ✅ **Indexes**: Optimized for common query patterns (owner, created_at, lookups)
- ✅ **Unique Constraints**: Prevents duplicate list names per owner
- ✅ **Updated At Trigger**: Automatic timestamp management

## Testing
- ✅ Migration applies cleanly on existing database
- ✅ Rollback removes all tables and constraints properly
- ✅ Re-application works without conflicts
- ✅ All foreign key relationships validated

## Database Schema
- `list` - User-created mech collections
- `list_mech` - Junction table (list_id, mech_id, quantity)

Closes CMB-8